### PR TITLE
Change "this" to "streamer.ws" for consistency with the lines above.

### DIFF
--- a/repeater.js
+++ b/repeater.js
@@ -137,7 +137,7 @@ Streamer.prototype = {
 
         this.ws.onopen = function() {
             if(streamer.destroyed) return streamer.ws.close();
-            streamer.log('Repeater conencted to agar');
+            streamer.log('Repeater connected to agar');
 
             //initialization emulation start
             var buf = new Buffer(5);
@@ -156,7 +156,7 @@ Streamer.prototype = {
                 for (var i=1;i<=server_key.length;++i) {
                     buf.writeUInt8(server_key.charCodeAt(i-1), i);
                 }
-                this.send(buf);
+                streamer.ws.send(buf);
             }
             //initialization emulation end
 


### PR DESCRIPTION
This isn't a bug exactly, since I believe "this" is bound to the same
object as "streamer.ws" at this point. However, I think streamer.ws was
intended, as it is consistent with the lines above.

Also, fix a typo.
